### PR TITLE
Sprint 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ vendor/
 data_snapshot
 
 .projectile-cache.eld
+
+*.pem

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -2,21 +2,29 @@
 package config
 
 import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
 	"flag"
 	"os"
 	"strconv"
 	"time"
 
+	"github.com/frolmr/metrics/pkg/fileconfig"
 	"github.com/frolmr/metrics/pkg/formatter"
 )
 
 const (
+	maxParamCount = 4
+
 	schemeEnvName         = "SCHEME"
 	addressEnvName        = "ADDRESS"
 	reportIntervalEnvName = "REPORT_INTERVAL"
 	pollIntervalEnvName   = "POLL_INTERVAL"
 	keyEnv                = "KEY"
 	rateLimitEnvName      = "RATE_LIMIT"
+	cryptoKeyEnvName      = "CRYPTO_KEY"
 
 	defaultScheme            = "http"
 	defaultAddress           = "localhost:8080"
@@ -36,10 +44,23 @@ type Config struct {
 	Key string
 
 	RateLimit int
+
+	CryptoKey *rsa.PublicKey
 }
 
 // NewConfig setups agents config: read flags and env variables.
+//
+//nolint:gocyclo,funlen // Too many parameters
 func NewConfig() (*Config, error) {
+	schemeValues := make([]string, 0, maxParamCount)
+	addressValues := make([]string, 0, maxParamCount)
+	reportIntervalValues := make([]int, 0, maxParamCount)
+	pollIntervalValues := make([]int, 0, maxParamCount)
+	rateLimitValues := make([]int, 0, maxParamCount)
+
+	keyValues := make([]string, 0, maxParamCount)
+	cryptoKeyValues := make([]string, 0, maxParamCount)
+
 	var (
 		serverScheme      string
 		serverHTTPAddress string
@@ -47,54 +68,175 @@ func NewConfig() (*Config, error) {
 		pollIntervalSec   int
 		key               string
 		rateLimit         int
+		cryptoKeyPath     string
+		configFile        string
 	)
 
-	flag.StringVar(&serverScheme, "s", defaultScheme, "server scheme: http or https")
-	flag.StringVar(&serverHTTPAddress, "a", defaultAddress, "address and port of the server")
-	flag.IntVar(&reportIntervalSec, "r", defaultReportIntervalSec, "report interval")
-	flag.IntVar(&pollIntervalSec, "p", defaultPollIntervalSec, "poll interval")
-	flag.StringVar(&key, "k", key, "encryption key")
-	flag.IntVar(&rateLimit, "l", defaultRateLimit, "requests to server rate limit")
+	schemeValues = append(schemeValues, defaultScheme)
+	addressValues = append(addressValues, defaultAddress)
+	reportIntervalValues = append(reportIntervalValues, defaultReportIntervalSec)
+	pollIntervalValues = append(pollIntervalValues, defaultPollIntervalSec)
+	rateLimitValues = append(rateLimitValues, defaultRateLimit)
+
+	flag.StringVar(&serverScheme, "s", "", "server scheme: http or https")
+	flag.StringVar(&serverHTTPAddress, "a", "", "address and port of the server")
+	flag.IntVar(&reportIntervalSec, "r", 0, "report interval")
+	flag.IntVar(&pollIntervalSec, "p", 0, "poll interval")
+	flag.IntVar(&rateLimit, "l", 0, "requests to server rate limit")
+	flag.StringVar(&key, "k", "", "encryption key")
+	flag.StringVar(&cryptoKeyPath, "crypto-key", "", "public crypto key path")
+	flag.StringVar(&configFile, "config", "", "path to config file")
 	flag.Parse()
 
-	if serverSchemeEnv := os.Getenv(schemeEnvName); serverSchemeEnv != "" {
-		serverScheme = serverSchemeEnv
+	if configFile != "" {
+		fileCfg, err := fileconfig.ReadAgentConfig(configFile)
+		if err != nil {
+			return nil, err
+		}
+		if fileCfg != nil {
+			if fileCfg.Address != "" {
+				addressValues = append(addressValues, fileCfg.Address)
+			}
+			if fileCfg.Scheme != "" {
+				schemeValues = append(schemeValues, fileCfg.Scheme)
+			}
+			if fileCfg.ReportIntervalSec != 0 {
+				reportIntervalValues = append(reportIntervalValues, fileCfg.ReportIntervalSec)
+			}
+			if fileCfg.PollIntervalSec != 0 {
+				pollIntervalValues = append(pollIntervalValues, fileCfg.PollIntervalSec)
+			}
+			if fileCfg.RateLimit != 0 {
+				rateLimitValues = append(rateLimitValues, fileCfg.RateLimit)
+			}
+			if fileCfg.Key != "" {
+				keyValues = append(keyValues, fileCfg.Key)
+			}
+			if fileCfg.CryptoKey != "" {
+				cryptoKeyValues = append(cryptoKeyValues, fileCfg.CryptoKey)
+			}
+		}
 	}
 
-	if err := formatter.CheckSchemeFormat(serverScheme); err != nil {
-		return nil, err
+	if serverScheme != "" {
+		schemeValues = append(schemeValues, serverScheme)
+	}
+
+	if serverHTTPAddress != "" {
+		addressValues = append(addressValues, serverHTTPAddress)
+	}
+
+	if reportIntervalSec != 0 {
+		reportIntervalValues = append(reportIntervalValues, reportIntervalSec)
+	}
+
+	if pollIntervalSec != 0 {
+		pollIntervalValues = append(pollIntervalValues, pollIntervalSec)
+	}
+
+	if rateLimit != 0 {
+		rateLimitValues = append(rateLimitValues, rateLimit)
+	}
+
+	if key != "" {
+		keyValues = append(keyValues, key)
+	}
+
+	if cryptoKeyPath != "" {
+		cryptoKeyValues = append(cryptoKeyValues, cryptoKeyPath)
+	}
+
+	if serverSchemeEnv := os.Getenv(schemeEnvName); serverSchemeEnv != "" {
+		schemeValues = append(schemeValues, serverSchemeEnv)
 	}
 
 	if serverHTTPAddressEnv := os.Getenv(addressEnvName); serverHTTPAddressEnv != "" {
-		serverHTTPAddress = serverHTTPAddressEnv
+		addressValues = append(addressValues, serverHTTPAddressEnv)
 	}
 
-	if err := formatter.CheckAddrFormat(serverHTTPAddress); err != nil {
-		return nil, err
+	if reportIntervalSecEnv, err := strconv.Atoi(os.Getenv(reportIntervalEnvName)); reportIntervalSecEnv != 0 {
+		if err == nil {
+			reportIntervalValues = append(reportIntervalValues, reportIntervalSecEnv)
+		}
 	}
 
-	if reportIntervalSecEnv, _ := strconv.Atoi(os.Getenv(reportIntervalEnvName)); reportIntervalSecEnv != 0 {
-		reportIntervalSec = reportIntervalSecEnv
-	}
-
-	if pollIntervalSecEnv, _ := strconv.Atoi(os.Getenv(pollIntervalEnvName)); pollIntervalSecEnv != 0 {
-		pollIntervalSec = pollIntervalSecEnv
-	}
-
-	if keyEnv := os.Getenv(keyEnv); keyEnv != "" {
-		key = keyEnv
+	if pollIntervalSecEnv, err := strconv.Atoi(os.Getenv(pollIntervalEnvName)); pollIntervalSecEnv != 0 {
+		if err == nil {
+			pollIntervalValues = append(pollIntervalValues, pollIntervalSecEnv)
+		}
 	}
 
 	if rateLimitEnv, _ := strconv.Atoi(os.Getenv(rateLimitEnvName)); rateLimitEnv != 0 {
-		rateLimit = rateLimitEnv
+		rateLimitValues = append(rateLimitValues, rateLimitEnv)
+	}
+
+	if keyEnv := os.Getenv(keyEnv); keyEnv != "" {
+		keyValues = append(keyValues, keyEnv)
+	}
+
+	if cryptoKeyEnv := os.Getenv(cryptoKeyEnvName); cryptoKeyEnv != "" {
+		cryptoKeyValues = append(cryptoKeyValues, cryptoKeyEnv)
+	}
+
+	schemeConfig := schemeValues[len(schemeValues)-1]
+	if err := formatter.CheckSchemeFormat(schemeConfig); err != nil {
+		return nil, err
+	}
+
+	addressConfig := addressValues[len(addressValues)-1]
+	if err := formatter.CheckAddrFormat(addressConfig); err != nil {
+		return nil, err
+	}
+
+	reportIntervalConfig := reportIntervalValues[len(reportIntervalValues)-1]
+	pollIntervalConfig := pollIntervalValues[len(pollIntervalValues)-1]
+	rateLimitConfig := rateLimitValues[len(rateLimitValues)-1]
+
+	var keyConfig string
+	if len(keyValues) != 0 {
+		keyConfig = keyValues[len(keyValues)-1]
+	}
+
+	var cryptoKeyConfig string
+	if len(cryptoKeyValues) != 0 {
+		cryptoKeyConfig = cryptoKeyValues[len(cryptoKeyValues)-1]
+	}
+
+	cryptoKey, err := loadPublicKey(cryptoKeyConfig)
+	if err != nil {
+		return nil, err
 	}
 
 	return &Config{
-		Scheme:         serverScheme,
-		HTTPAddress:    serverHTTPAddress,
-		ReportInterval: time.Duration(reportIntervalSec) * time.Second,
-		PollInterval:   time.Duration(pollIntervalSec) * time.Second,
-		Key:            key,
-		RateLimit:      rateLimit,
+		Scheme:         schemeConfig,
+		HTTPAddress:    addressConfig,
+		ReportInterval: time.Duration(reportIntervalConfig) * time.Second,
+		PollInterval:   time.Duration(pollIntervalConfig) * time.Second,
+		Key:            keyConfig,
+		RateLimit:      rateLimitConfig,
+		CryptoKey:      cryptoKey,
 	}, nil
+}
+
+func loadPublicKey(publicKeyPath string) (*rsa.PublicKey, error) {
+	if publicKeyPath == "" {
+		return nil, nil
+	}
+
+	keyBytes, err := os.ReadFile(publicKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	block, _ := pem.Decode(keyBytes)
+	if block == nil {
+		return nil, errors.New("failed to parse PEM block containing the public key")
+	}
+
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return pub.(*rsa.PublicKey), nil
 }

--- a/internal/agent/config/config_test.go
+++ b/internal/agent/config/config_test.go
@@ -3,10 +3,12 @@ package config
 import (
 	"flag"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseFlags(t *testing.T) {
@@ -284,5 +286,279 @@ func TestParseRateLimitFlag(t *testing.T) {
 		os.Clearenv()
 
 		assert.Equal(t, test.want.rateLimit, config.RateLimit)
+	}
+}
+
+func TestParseCryptoKeyFlag(t *testing.T) {
+	pubKey := `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1SU1LfVLPHCozMxH2Mo
+4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u
++qKhbwKfBstIs+bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyeh
+kd3qqGElvW/VDL5AaWTg0nLVkjRo9z+40RQzuVaE8AkAFmxZzow3x+VJkAE/Ag+Z
+cL5HBPpE5oVuAfQwF1/7+9VP3Mp9v6sED6bFiPQ0NdwCYp6j6X7WQ8CJ7M5kQ+7J
+9Z6MCQD5qjU1fXg9JwZw5V5Z0X6J+ZQ0C3c0yW0q5fYDP6wUcJb6MnN4B7pXwJ2d
+zQIDAQAB
+-----END PUBLIC KEY-----`
+
+	tmpFile, err := os.CreateTemp("", "public_key_*.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString(pubKey); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	type want struct {
+		cryptoKeyExists bool
+	}
+	tests := []struct {
+		name     string
+		args     []string
+		envName  string
+		envValue string
+		want     want
+		wantErr  bool
+	}{
+		{
+			name:    "no key specified",
+			args:    []string{},
+			want:    want{cryptoKeyExists: false},
+			wantErr: false,
+		},
+		{
+			name:    "key from flag",
+			args:    []string{"-crypto-key", tmpFile.Name()},
+			want:    want{cryptoKeyExists: true},
+			wantErr: false,
+		},
+		{
+			name:     "key from env overrides flag",
+			args:     []string{"-crypto-key", "nonexistent.pem"},
+			envName:  "CRYPTO_KEY",
+			envValue: tmpFile.Name(),
+			want:     want{cryptoKeyExists: true},
+			wantErr:  false,
+		},
+		{
+			name:    "invalid key path",
+			args:    []string{"-crypto-key", "nonexistent.pem"},
+			want:    want{cryptoKeyExists: false},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.envName != "" {
+				os.Setenv(test.envName, test.envValue)
+				defer os.Unsetenv(test.envName)
+			}
+
+			os.Args = append([]string{"cmd"}, test.args...)
+			flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+
+			config, err := NewConfig()
+			if (err != nil) != test.wantErr {
+				t.Errorf("NewConfig() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+
+			if test.wantErr {
+				return
+			}
+
+			if test.want.cryptoKeyExists {
+				if config.CryptoKey == nil {
+					t.Error("Expected crypto key to be loaded, but got nil")
+				}
+			} else {
+				if config.CryptoKey != nil {
+					t.Error("Expected no crypto key, but got one")
+				}
+			}
+		})
+	}
+}
+
+func TestLoadPublicKey(t *testing.T) {
+	validPubKey := `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1SU1LfVLPHCozMxH2Mo
+4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u
++qKhbwKfBstIs+bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyeh
+kd3qqGElvW/VDL5AaWTg0nLVkjRo9z+40RQzuVaE8AkAFmxZzow3x+VJkAE/Ag+Z
+cL5HBPpE5oVuAfQwF1/7+9VP3Mp9v6sED6bFiPQ0NdwCYp6j6X7WQ8CJ7M5kQ+7J
+9Z6MCQD5qjU1fXg9JwZw5V5Z0X6J+ZQ0C3c0yW0q5fYDP6wUcJb6MnN4B7pXwJ2d
+zQIDAQAB
+-----END PUBLIC KEY-----`
+
+	validTmpFile, err := os.CreateTemp("", "valid_public_key_*.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(validTmpFile.Name())
+
+	if _, WriteErr := validTmpFile.WriteString(validPubKey); err != nil {
+		t.Fatal(WriteErr)
+	}
+	if CloseErr := validTmpFile.Close(); err != nil {
+		t.Fatal(CloseErr)
+	}
+
+	invalidPubKey := `-----BEGIN PUBLIC KEY-----
+INVALID KEY DATA
+-----END PUBLIC KEY-----`
+
+	invalidTmpFile, err := os.CreateTemp("", "invalid_public_key_*.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(invalidTmpFile.Name())
+
+	if _, err := invalidTmpFile.WriteString(invalidPubKey); err != nil {
+		t.Fatal(err)
+	}
+	if err := invalidTmpFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		keyPath string
+		wantKey bool
+		wantErr bool
+	}{
+		{
+			name:    "empty path",
+			keyPath: "",
+			wantKey: false,
+			wantErr: false,
+		},
+		{
+			name:    "valid key",
+			keyPath: validTmpFile.Name(),
+			wantKey: true,
+			wantErr: false,
+		},
+		{
+			name:    "invalid key format",
+			keyPath: invalidTmpFile.Name(),
+			wantKey: false,
+			wantErr: true,
+		},
+		{
+			name:    "nonexistent file",
+			keyPath: "nonexistent.pem",
+			wantKey: false,
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := loadPublicKey(test.keyPath)
+			if (err != nil) != test.wantErr {
+				t.Errorf("loadPublicKey() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+			if (got != nil) != test.wantKey {
+				t.Errorf("loadPublicKey() got key = %v, want key %v", got != nil, test.wantKey)
+			}
+		})
+	}
+}
+
+func TestAgentConfigPriority(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	configContent := `{
+		"address": "json:8080",
+		"report_interval": 5,
+		"poll_interval": 3,
+		"rate_limit": 7,
+		"key": "json_key"
+	}`
+
+	configPath := filepath.Join(tmpDir, "config.json")
+	err := os.WriteFile(configPath, []byte(configContent), 0600)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		args       []string
+		envVars    map[string]string
+		configFile string
+		expected   Config
+	}{
+		{
+			name:       "json config only",
+			configFile: configPath,
+			expected: Config{
+				HTTPAddress:    "json:8080",
+				ReportInterval: 5 * time.Second,
+				PollInterval:   3 * time.Second,
+				RateLimit:      7,
+				Key:            "json_key",
+			},
+		},
+		{
+			name:       "flag overrides json",
+			configFile: configPath,
+			args:       []string{"-a", "flag:8080", "-r", "3", "-k", "flag_key"},
+			expected: Config{
+				HTTPAddress:    "flag:8080",
+				ReportInterval: 3 * time.Second,
+				PollInterval:   3 * time.Second,
+				RateLimit:      7,
+				Key:            "flag_key",
+			},
+		},
+		{
+			name:       "env override all",
+			configFile: configPath,
+			envVars: map[string]string{
+				"ADDRESS":         "env:8080",
+				"REPORT_INTERVAL": "10",
+				"KEY":             "env_key",
+			},
+			args: []string{"-a", "flag:8080", "-r", "3", "-k", "flag_key"},
+			expected: Config{
+				HTTPAddress:    "env:8080",
+				ReportInterval: 10 * time.Second,
+				PollInterval:   3 * time.Second,
+				RateLimit:      7,
+				Key:            "env_key",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envVars {
+				os.Setenv(k, v)
+			}
+			defer func() {
+				for k := range tt.envVars {
+					os.Unsetenv(k)
+				}
+			}()
+
+			args := append([]string{"-config", tt.configFile}, tt.args...)
+			os.Args = append([]string{"cmd"}, args...)
+			flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+
+			cfg, err := NewConfig()
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expected.HTTPAddress, cfg.HTTPAddress)
+			assert.Equal(t, tt.expected.ReportInterval, cfg.ReportInterval)
+			assert.Equal(t, tt.expected.PollInterval, cfg.PollInterval)
+			assert.Equal(t, tt.expected.RateLimit, cfg.RateLimit)
+			assert.Equal(t, tt.expected.Key, cfg.Key)
+		})
 	}
 }

--- a/internal/agent/metrics/reporter_test.go
+++ b/internal/agent/metrics/reporter_test.go
@@ -3,22 +3,33 @@ package metrics
 import (
 	"bytes"
 	"compress/gzip"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"syscall"
 	"testing"
 
 	"github.com/frolmr/metrics/internal/agent/config"
 	"github.com/frolmr/metrics/internal/domain"
+	"github.com/frolmr/metrics/pkg/signer"
 	"github.com/go-resty/resty/v2"
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func generateTestRSAKeys(t *testing.T) (*rsa.PrivateKey, *rsa.PublicKey) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	return privateKey, &privateKey.PublicKey
+}
 
 func TestMetricsReporter(t *testing.T) {
 	tests := []struct {
@@ -251,4 +262,280 @@ func TestIsConnectionRefused(t *testing.T) {
 			assert.Equal(t, tt.expected, isConnectionRefused(tt.err))
 		})
 	}
+}
+
+func TestReportMetricsWithEncryption(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	publicKey := &privateKey.PublicKey
+
+	cfg := &config.Config{
+		Scheme:      "http",
+		HTTPAddress: "localhost:8080",
+		CryptoKey:   publicKey,
+	}
+
+	mc := &MetricsCollection{
+		GaugeMetrics: map[string]float64{
+			"test_gauge": 123.45,
+		},
+		ReportClient: resty.New(),
+		Config:       cfg,
+	}
+
+	httpmock.ActivateNonDefault(mc.ReportClient.GetClient())
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder(
+		"POST",
+		"http://localhost:8080/updates/",
+		func(req *http.Request) (*http.Response, error) {
+			assert.Equal(t, "gzip", req.Header.Get("Content-Encoding"))
+			assert.Equal(t, "application/json", req.Header.Get("Content-Type"))
+
+			gz, err := gzip.NewReader(req.Body)
+			require.NoError(t, err)
+			defer gz.Close()
+
+			encryptedData, err := io.ReadAll(gz)
+			require.NoError(t, err)
+
+			decryptedData, err := rsa.DecryptPKCS1v15(rand.Reader, privateKey, encryptedData)
+			require.NoError(t, err)
+
+			var metrics []domain.Metrics
+			err = json.Unmarshal(decryptedData, &metrics)
+			require.NoError(t, err)
+			assert.Len(t, metrics, 1)
+			assert.Equal(t, "test_gauge", metrics[0].ID)
+			assert.Equal(t, 123.45, *metrics[0].Value)
+
+			return httpmock.NewJsonResponse(http.StatusOK, map[string]string{"status": "OK"})
+		},
+	)
+
+	mc.ReportMetrics()
+
+	info := httpmock.GetCallCountInfo()
+	assert.Equal(t, 1, info["POST http://localhost:8080/updates/"])
+}
+
+func TestReportMetricsWithoutEncryption(t *testing.T) {
+	cfg := &config.Config{
+		Scheme:      "http",
+		HTTPAddress: "localhost:8080",
+		CryptoKey:   nil,
+	}
+
+	mc := &MetricsCollection{
+		GaugeMetrics: map[string]float64{
+			"test_gauge": 123.45,
+		},
+		ReportClient: resty.New(),
+		Config:       cfg,
+	}
+
+	httpmock.ActivateNonDefault(mc.ReportClient.GetClient())
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder(
+		"POST",
+		"http://localhost:8080/updates/",
+		func(req *http.Request) (*http.Response, error) {
+			assert.Equal(t, "gzip", req.Header.Get("Content-Encoding"))
+			assert.Equal(t, "application/json", req.Header.Get("Content-Type"))
+
+			gz, err := gzip.NewReader(req.Body)
+			require.NoError(t, err)
+			defer gz.Close()
+
+			var metrics []domain.Metrics
+			err = json.NewDecoder(gz).Decode(&metrics)
+			require.NoError(t, err)
+			assert.Len(t, metrics, 1)
+			assert.Equal(t, "test_gauge", metrics[0].ID)
+			assert.Equal(t, 123.45, *metrics[0].Value)
+
+			return httpmock.NewJsonResponse(http.StatusOK, map[string]string{"status": "OK"})
+		},
+	)
+
+	mc.ReportMetrics()
+
+	info := httpmock.GetCallCountInfo()
+	assert.Equal(t, 1, info["POST http://localhost:8080/updates/"])
+}
+
+func TestReportMetricsWithEncryptionAndSignature(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	publicKey := &privateKey.PublicKey
+
+	cfg := &config.Config{
+		Scheme:      "http",
+		HTTPAddress: "localhost:8080",
+		CryptoKey:   publicKey,
+		Key:         "test-signature-key",
+	}
+
+	mc := &MetricsCollection{
+		GaugeMetrics: map[string]float64{
+			"test_gauge": 123.45,
+		},
+		ReportClient: resty.New(),
+		Config:       cfg,
+	}
+
+	httpmock.ActivateNonDefault(mc.ReportClient.GetClient())
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder(
+		"POST",
+		"http://localhost:8080/updates/",
+		func(req *http.Request) (*http.Response, error) {
+			assert.Equal(t, "gzip", req.Header.Get("Content-Encoding"))
+			assert.Equal(t, "application/json", req.Header.Get("Content-Type"))
+			assert.NotEmpty(t, req.Header.Get(domain.SignatureHeader), "signature should be present")
+
+			gz, err := gzip.NewReader(req.Body)
+			require.NoError(t, err)
+			defer gz.Close()
+
+			encryptedData, err := io.ReadAll(gz)
+			require.NoError(t, err)
+
+			decryptedData, err := rsa.DecryptPKCS1v15(rand.Reader, privateKey, encryptedData)
+			require.NoError(t, err)
+
+			signature := req.Header.Get(domain.SignatureHeader)
+			expectedSignature := signer.SignPayloadWithKey(decryptedData, []byte(cfg.Key))
+			assert.Equal(t, hex.EncodeToString(expectedSignature), signature, "signature verification failed")
+
+			var metrics []domain.Metrics
+			err = json.Unmarshal(decryptedData, &metrics)
+			require.NoError(t, err)
+			assert.Len(t, metrics, 1)
+			assert.Equal(t, "test_gauge", metrics[0].ID)
+			assert.Equal(t, 123.45, *metrics[0].Value)
+
+			return httpmock.NewJsonResponse(http.StatusOK, map[string]string{"status": "OK"})
+		},
+	)
+
+	mc.ReportMetrics()
+
+	info := httpmock.GetCallCountInfo()
+	assert.Equal(t, 1, info["POST http://localhost:8080/updates/"])
+}
+
+func TestReportMetricsWithLargePayloadEncryption(t *testing.T) {
+	privateKey, publicKey := generateTestRSAKeys(t)
+
+	cfg := &config.Config{
+		Scheme:      "http",
+		HTTPAddress: "localhost:8080",
+		CryptoKey:   publicKey,
+	}
+
+	largeMetrics := make([]domain.Metrics, 0)
+	for i := 0; i < 100; i++ {
+		largeMetrics = append(largeMetrics, domain.Metrics{
+			ID:    "test_gauge_" + strconv.Itoa(i),
+			MType: domain.GaugeType,
+			Value: func() *float64 { v := float64(i); return &v }(),
+		})
+	}
+
+	mc := &MetricsCollection{
+		GaugeMetrics:   map[string]float64{},
+		CounterMetrics: map[string]int64{},
+		ReportClient:   resty.New(),
+		Config:         cfg,
+	}
+
+	httpmock.ActivateNonDefault(mc.ReportClient.GetClient())
+	defer httpmock.DeactivateAndReset()
+
+	var receivedPayload []byte
+	httpmock.RegisterResponder(
+		"POST",
+		"http://localhost:8080/updates/",
+		func(req *http.Request) (*http.Response, error) {
+			gz, err := gzip.NewReader(req.Body)
+			require.NoError(t, err)
+			defer gz.Close()
+
+			encryptedData, err := io.ReadAll(gz)
+			require.NoError(t, err)
+			receivedPayload = encryptedData
+
+			return httpmock.NewJsonResponse(http.StatusOK, map[string]string{"status": "OK"})
+		},
+	)
+
+	err := mc.reportMetrics(largeMetrics)
+	require.NoError(t, err)
+
+	assert.True(t, len(receivedPayload) > privateKey.Size())
+	assert.Equal(t, 0, len(receivedPayload)%privateKey.Size(), "payload should be multiple of key size")
+
+	chunkSize := privateKey.Size()
+	var decryptedData []byte
+
+	for i := 0; i < len(receivedPayload); i += chunkSize {
+		chunk := receivedPayload[i : i+chunkSize]
+		decryptedChunk, DecryptErr := rsa.DecryptPKCS1v15(rand.Reader, privateKey, chunk)
+		require.NoError(t, DecryptErr)
+		decryptedData = append(decryptedData, decryptedChunk...)
+	}
+
+	var metrics []domain.Metrics
+	err = json.Unmarshal(decryptedData, &metrics)
+	require.NoError(t, err)
+	assert.Len(t, metrics, 100)
+}
+
+func TestReportMetricsEncryptionFailure(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	publicKey := &privateKey.PublicKey
+
+	failReader := &failingReader{}
+
+	oldReader := rand.Reader
+	rand.Reader = failReader
+	defer func() { rand.Reader = oldReader }()
+
+	cfg := &config.Config{
+		Scheme:      "http",
+		HTTPAddress: "localhost:8080",
+		CryptoKey:   publicKey,
+	}
+
+	mc := &MetricsCollection{
+		GaugeMetrics: map[string]float64{
+			"test_gauge": 123.45,
+		},
+		CounterMetrics: map[string]int64{},
+		ReportClient:   resty.New(),
+		Config:         cfg,
+	}
+
+	metrics := []domain.Metrics{
+		{
+			ID:    "test_gauge",
+			MType: domain.GaugeType,
+			Value: func() *float64 { v := 123.45; return &v }(),
+		},
+	}
+
+	err = mc.reportMetrics(metrics)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mock reader error")
+}
+
+type failingReader struct{}
+
+func (r *failingReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("mock reader error")
 }

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -2,15 +2,22 @@
 package config
 
 import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
 	"flag"
 	"os"
 	"strconv"
 	"time"
 
+	"github.com/frolmr/metrics/pkg/fileconfig"
 	"github.com/frolmr/metrics/pkg/formatter"
 )
 
 const (
+	maxParamCount = 4
+
 	schemeEnvName      = "SCHEME"
 	addressEnvName     = "ADDRESS"
 	storeIntervalEnv   = "STORE_INTERVAL"
@@ -18,7 +25,10 @@ const (
 	restoreEnv         = "RESTORE"
 	databaseDsnEnv     = "DATABASE_DSN"
 	keyEnv             = "KEY"
+	cryptoKeyEnvName   = "CRYPTO_KEY"
+)
 
+const (
 	defaultScheme          = "http"
 	defaultAddress         = "localhost:8080"
 	defaultStoreInterval   = 300
@@ -26,7 +36,7 @@ const (
 	defaultRestore         = false
 )
 
-// Config atructure to store server configuration.
+// Config structure to store server configuration.
 type Config struct {
 	Scheme      string
 	HTTPAddress string
@@ -36,78 +46,229 @@ type Config struct {
 	FileStoragePath string
 	Restore         bool
 
-	Key string
-
+	Key       string
+	CryptoKey *rsa.PrivateKey
 	Profiling bool
 }
 
 // NewConfig setups server config: read flags and env variables.
+//
+//nolint:gocyclo,funlen // Too many parameters
 func NewConfig() (*Config, error) {
+	schemeValues := make([]string, 0, maxParamCount)
+	addressValues := make([]string, 0, maxParamCount)
+	databaseValues := make([]string, 0, maxParamCount)
+	filePathValues := make([]string, 0, maxParamCount)
+
+	storeIntervalValues := make([]int, 0, maxParamCount)
+
+	restoreValues := make([]bool, 0, maxParamCount)
+
+	keyValues := make([]string, 0, maxParamCount)
+	cryptoKeyValues := make([]string, 0, maxParamCount)
+
 	var (
 		serverScheme      string
 		serverHTTPAddress string
 		databaseDsn       string
 		storeIntervalSec  int
 		fileStoragePath   string
-		restore           bool
+		restore           string
 		key               string
+		cryptoKeyPath     string
 		profile           bool
+		configFile        string
 	)
 
-	flag.StringVar(&serverScheme, "s", defaultScheme, "server scheme: http or https")
-	flag.StringVar(&serverHTTPAddress, "a", defaultAddress, "address and port of the server")
-	flag.StringVar(&databaseDsn, "d", databaseDsn, "DB DSN")
-	flag.IntVar(&storeIntervalSec, "i", defaultStoreInterval, "snapshot data interval")
-	flag.StringVar(&fileStoragePath, "f", defaultFileStoragePath, "snapshot file path")
-	flag.BoolVar(&restore, "r", defaultRestore, "bool flag for set snapshoting")
-	flag.StringVar(&key, "k", key, "encryption key")
+	schemeValues = append(schemeValues, defaultScheme)
+	addressValues = append(addressValues, defaultAddress)
+	storeIntervalValues = append(storeIntervalValues, defaultStoreInterval)
+	filePathValues = append(filePathValues, defaultFileStoragePath)
+	restoreValues = append(restoreValues, defaultRestore)
+
+	flag.StringVar(&serverScheme, "s", "", "server scheme: http or https")
+	flag.StringVar(&serverHTTPAddress, "a", "", "address and port of the server")
+	flag.StringVar(&databaseDsn, "d", "", "DB DSN")
+	flag.IntVar(&storeIntervalSec, "i", 0, "snapshot data interval")
+	flag.StringVar(&fileStoragePath, "f", "", "snapshot file path")
+	flag.StringVar(&restore, "r", "", "bool flag for set snapshoting")
+	flag.StringVar(&key, "k", "", "encryption key")
+	flag.StringVar(&cryptoKeyPath, "crypto-key", "", "path to private key for decryption")
 	flag.BoolVar(&profile, "p", profile, "bool flag for app profiling")
+	flag.StringVar(&configFile, "config", "", "path to config file")
 	flag.Parse()
 
-	if serverSchemeEnv := os.Getenv(schemeEnvName); serverSchemeEnv != "" {
-		serverScheme = serverSchemeEnv
+	if configFile != "" {
+		fileCfg, err := fileconfig.ReadServerConfig(configFile)
+		if err != nil {
+			return nil, err
+		}
+		if fileCfg != nil {
+			if fileCfg.Address != "" {
+				addressValues = append(addressValues, fileCfg.Address)
+			}
+			if fileCfg.Scheme != "" {
+				schemeValues = append(schemeValues, fileCfg.Scheme)
+			}
+			if fileCfg.Key != "" {
+				keyValues = append(keyValues, fileCfg.Key)
+			}
+			if fileCfg.CryptoKey != "" {
+				cryptoKeyValues = append(cryptoKeyValues, fileCfg.CryptoKey)
+			}
+			if fileCfg.Restore {
+				restoreValues = append(restoreValues, fileCfg.Restore)
+			}
+			if fileCfg.StoreIntervalSec != 0 {
+				storeIntervalValues = append(storeIntervalValues, fileCfg.StoreIntervalSec)
+			}
+			if fileCfg.StoreFile != "" {
+				filePathValues = append(filePathValues, fileCfg.StoreFile)
+			}
+			if fileCfg.DatabaseDSN != "" {
+				databaseValues = append(databaseValues, fileCfg.DatabaseDSN)
+			}
+		}
 	}
 
-	if err := formatter.CheckSchemeFormat(serverScheme); err != nil {
-		return nil, err
+	if serverScheme != "" {
+		schemeValues = append(schemeValues, serverScheme)
+	}
+
+	if serverHTTPAddress != "" {
+		addressValues = append(addressValues, serverHTTPAddress)
+	}
+
+	if storeIntervalSec != 0 {
+		storeIntervalValues = append(storeIntervalValues, storeIntervalSec)
+	}
+
+	if databaseDsn != "" {
+		databaseValues = append(databaseValues, databaseDsn)
+	}
+
+	if fileStoragePath != "" {
+		filePathValues = append(filePathValues, fileStoragePath)
+	}
+
+	if restore != "" {
+		if restoreKey, err := strconv.ParseBool(restore); err == nil {
+			restoreValues = append(restoreValues, restoreKey)
+		}
+	}
+
+	if key != "" {
+		keyValues = append(keyValues, key)
+	}
+
+	if cryptoKeyPath != "" {
+		cryptoKeyValues = append(cryptoKeyValues, cryptoKeyPath)
+	}
+
+	if serverSchemeEnv := os.Getenv(schemeEnvName); serverSchemeEnv != "" {
+		schemeValues = append(schemeValues, serverSchemeEnv)
 	}
 
 	if serverHTTPAddressEnv := os.Getenv(addressEnvName); serverHTTPAddressEnv != "" {
-		serverHTTPAddress = serverHTTPAddressEnv
-	}
-
-	if err := formatter.CheckAddrFormat(serverHTTPAddress); err != nil {
-		return nil, err
+		addressValues = append(addressValues, serverHTTPAddressEnv)
 	}
 
 	if databaseDsnEnv := os.Getenv(databaseDsnEnv); databaseDsnEnv != "" {
-		databaseDsn = databaseDsnEnv
+		databaseValues = append(databaseValues, databaseDsnEnv)
 	}
 
-	if storeIntervalSecEnv, _ := strconv.Atoi(os.Getenv(storeIntervalEnv)); storeIntervalSecEnv != 0 {
-		storeIntervalSec = storeIntervalSecEnv
+	if storeIntervalSecEnv, err := strconv.Atoi(os.Getenv(storeIntervalEnv)); storeIntervalSecEnv != 0 {
+		if err == nil {
+			storeIntervalValues = append(storeIntervalValues, storeIntervalSecEnv)
+		}
 	}
 
 	if fileStoragePathEnv := os.Getenv(fileStoragePathEnv); fileStoragePathEnv != "" {
-		fileStoragePath = fileStoragePathEnv
+		filePathValues = append(filePathValues, fileStoragePathEnv)
 	}
 
 	if restoreEnv, err := strconv.ParseBool(os.Getenv(restoreEnv)); err == nil {
-		restore = restoreEnv
+		restoreValues = append(restoreValues, restoreEnv)
 	}
 
 	if keyEnv := os.Getenv(keyEnv); keyEnv != "" {
-		key = keyEnv
+		keyValues = append(keyValues, keyEnv)
+	}
+
+	if cryptoKeyEnv := os.Getenv(cryptoKeyEnvName); cryptoKeyEnv != "" {
+		cryptoKeyValues = append(cryptoKeyValues, cryptoKeyEnv)
+	}
+
+	schemeConfig := schemeValues[len(schemeValues)-1]
+	if err := formatter.CheckSchemeFormat(schemeConfig); err != nil {
+		return nil, err
+	}
+
+	addressConfig := addressValues[len(addressValues)-1]
+	if err := formatter.CheckAddrFormat(addressConfig); err != nil {
+		return nil, err
+	}
+
+	storeIntervalConfig := storeIntervalValues[len(storeIntervalValues)-1]
+	fileStorageConfig := filePathValues[len(filePathValues)-1]
+	restoreConfig := restoreValues[len(restoreValues)-1]
+
+	var databaseDSNConfig string
+	if len(databaseValues) != 0 {
+		databaseDSNConfig = databaseValues[len(databaseValues)-1]
+	}
+
+	var keyConfig string
+	if len(keyValues) != 0 {
+		keyConfig = keyValues[len(keyValues)-1]
+	}
+
+	var cryptoKeyConfig string
+	if len(cryptoKeyValues) != 0 {
+		cryptoKeyConfig = cryptoKeyValues[len(cryptoKeyValues)-1]
+	}
+
+	privateKey, err := loadPrivateKey(cryptoKeyConfig)
+	if err != nil {
+		return nil, err
 	}
 
 	return &Config{
-		Scheme:          serverScheme,
-		HTTPAddress:     serverHTTPAddress,
-		DatabaseDSN:     databaseDsn,
-		StoreInterval:   time.Duration(storeIntervalSec) * time.Second,
-		FileStoragePath: fileStoragePath,
-		Restore:         restore,
-		Key:             key,
+		Scheme:          schemeConfig,
+		HTTPAddress:     addressConfig,
+		DatabaseDSN:     databaseDSNConfig,
+		StoreInterval:   time.Duration(storeIntervalConfig) * time.Second,
+		FileStoragePath: fileStorageConfig,
+		Restore:         restoreConfig,
+		Key:             keyConfig,
+		CryptoKey:       privateKey,
 		Profiling:       profile,
 	}, nil
+}
+
+func loadPrivateKey(path string) (*rsa.PrivateKey, error) {
+	if path == "" {
+		return nil, nil
+	}
+
+	keyBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	block, _ := pem.Decode(keyBytes)
+	if block == nil {
+		return nil, errors.New("failed to parse PEM block containing the private key")
+	}
+
+	priv, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		return key.(*rsa.PrivateKey), nil
+	}
+
+	return priv, nil
 }

--- a/internal/server/config/config_test.go
+++ b/internal/server/config/config_test.go
@@ -1,12 +1,18 @@
 package config
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"flag"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseHostFlags(t *testing.T) {
@@ -337,5 +343,290 @@ func TestParseKeyFlag(t *testing.T) {
 		os.Clearenv()
 
 		assert.Equal(t, test.want.key, config.Key)
+	}
+}
+
+func TestCryptoKeyConfig(t *testing.T) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	privKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privKey),
+	})
+
+	tmpFile, err := os.CreateTemp("", "private_key_*.pem")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.Write(privKeyPEM)
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	type testCase struct {
+		name          string
+		args          []string
+		envVars       map[string]string
+		wantKeyLoaded bool
+		wantErr       bool
+		wantKeyExists bool
+	}
+
+	tests := []testCase{
+		{
+			name:          "flag - no key specified",
+			args:          []string{},
+			wantKeyLoaded: false,
+			wantErr:       false,
+			wantKeyExists: false,
+		},
+		{
+			name:          "flag - valid key path",
+			args:          []string{"-crypto-key", tmpFile.Name()},
+			wantKeyLoaded: true,
+			wantErr:       false,
+			wantKeyExists: true,
+		},
+		{
+			name:          "flag - invalid key path",
+			args:          []string{"-crypto-key", "nonexistent.pem"},
+			wantKeyLoaded: false,
+			wantErr:       true,
+			wantKeyExists: false,
+		},
+		{
+			name:          "env - no key specified",
+			envVars:       map[string]string{},
+			wantKeyLoaded: false,
+			wantErr:       false,
+			wantKeyExists: false,
+		},
+		{
+			name:          "env - valid key path",
+			envVars:       map[string]string{"CRYPTO_KEY": tmpFile.Name()},
+			wantKeyLoaded: true,
+			wantErr:       false,
+			wantKeyExists: true,
+		},
+		{
+			name:          "env - invalid key path",
+			envVars:       map[string]string{"CRYPTO_KEY": "nonexistent.pem"},
+			wantKeyLoaded: false,
+			wantErr:       true,
+			wantKeyExists: false,
+		},
+		{
+			name:          "flag and env - env overrides flag with valid path",
+			args:          []string{"-crypto-key", "nonexistent.pem"},
+			envVars:       map[string]string{"CRYPTO_KEY": tmpFile.Name()},
+			wantKeyLoaded: true,
+			wantErr:       false,
+			wantKeyExists: true,
+		},
+		{
+			name:          "flag and env - env overrides flag with invalid path",
+			args:          []string{"-crypto-key", tmpFile.Name()},
+			envVars:       map[string]string{"CRYPTO_KEY": "nonexistent.pem"},
+			wantKeyLoaded: false,
+			wantErr:       true,
+			wantKeyExists: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for k, v := range test.envVars {
+				os.Setenv(k, v)
+			}
+			defer func() {
+				for k := range test.envVars {
+					os.Unsetenv(k)
+				}
+			}()
+
+			os.Args = append([]string{"cmd"}, test.args...)
+			flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+
+			config, err := NewConfig()
+
+			if test.wantErr {
+				require.Error(t, err, "Expected error but got none")
+				return
+			}
+			require.NoError(t, err, "Unexpected error")
+
+			if test.wantKeyExists {
+				require.NotNil(t, config.CryptoKey, "Expected crypto key to be loaded")
+			} else {
+				require.Nil(t, config.CryptoKey, "Expected no crypto key to be loaded")
+			}
+		})
+	}
+}
+
+func TestLoadPrivateKey(t *testing.T) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	privKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privKey),
+	})
+
+	validTmpFile, err := os.CreateTemp("", "valid_private_key_*.pem")
+	require.NoError(t, err)
+	defer os.Remove(validTmpFile.Name())
+
+	_, err = validTmpFile.Write(privKeyPEM)
+	require.NoError(t, err)
+	require.NoError(t, validTmpFile.Close())
+
+	invalidTmpFile, err := os.CreateTemp("", "invalid_private_key_*.pem")
+	require.NoError(t, err)
+	defer os.Remove(invalidTmpFile.Name())
+
+	_, err = invalidTmpFile.Write([]byte("invalid key data"))
+	require.NoError(t, err)
+	require.NoError(t, invalidTmpFile.Close())
+
+	tests := []struct {
+		name    string
+		keyPath string
+		wantKey bool
+		wantErr bool
+	}{
+		{
+			name:    "empty path",
+			keyPath: "",
+			wantKey: false,
+			wantErr: false,
+		},
+		{
+			name:    "valid key",
+			keyPath: validTmpFile.Name(),
+			wantKey: true,
+			wantErr: false,
+		},
+		{
+			name:    "invalid key format",
+			keyPath: invalidTmpFile.Name(),
+			wantKey: false,
+			wantErr: true,
+		},
+		{
+			name:    "nonexistent file",
+			keyPath: "nonexistent.pem",
+			wantKey: false,
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := loadPrivateKey(test.keyPath)
+			if (err != nil) != test.wantErr {
+				t.Errorf("loadPrivateKey() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+			if (got != nil) != test.wantKey {
+				t.Errorf("loadPrivateKey() got key = %v, want key %v", got != nil, test.wantKey)
+			}
+		})
+	}
+}
+
+func TestServerConfigPriority(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	configContent := `{
+		"address": "json:8080",
+		"store_interval": 10,
+		"store_file": "/json/store.db",
+		"restore": true,
+		"database_dsn": "json_dsn",
+		"key": "json_key"
+	}`
+	configPath := filepath.Join(tmpDir, "config.json")
+	err := os.WriteFile(configPath, []byte(configContent), 0600)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		args       []string
+		envVars    map[string]string
+		configFile string
+		expected   Config
+	}{
+		{
+			name:       "json config only",
+			configFile: configPath,
+			expected: Config{
+				HTTPAddress:     "json:8080",
+				StoreInterval:   10 * time.Second,
+				FileStoragePath: "/json/store.db",
+				Restore:         true,
+				DatabaseDSN:     "json_dsn",
+				Key:             "json_key",
+			},
+		},
+		{
+			name:       "keys overrides json",
+			configFile: configPath,
+			args:       []string{"-a", "flag:8080", "-i", "15", "-k", "flag_key"},
+			expected: Config{
+				HTTPAddress:     "flag:8080",
+				StoreInterval:   15 * time.Second,
+				FileStoragePath: "/json/store.db",
+				Restore:         true,
+				DatabaseDSN:     "json_dsn",
+				Key:             "flag_key",
+			},
+		},
+		{
+			name:       "envs override all",
+			configFile: configPath,
+			envVars: map[string]string{
+				"ADDRESS":           "env:8080",
+				"STORE_INTERVAL":    "60",
+				"FILE_STORAGE_PATH": "/env/store.db",
+				"KEY":               "env_key",
+			},
+			args: []string{"-a", "flag:8080", "-i", "15", "-k", "flag_key"},
+			expected: Config{
+				HTTPAddress:     "env:8080",
+				StoreInterval:   60 * time.Second,
+				FileStoragePath: "/env/store.db",
+				Restore:         true,
+				DatabaseDSN:     "json_dsn",
+				Key:             "env_key",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envVars {
+				os.Setenv(k, v)
+			}
+			defer func() {
+				for k := range tt.envVars {
+					os.Unsetenv(k)
+				}
+			}()
+
+			args := append([]string{"-config", tt.configFile}, tt.args...)
+			os.Args = append([]string{"cmd"}, args...)
+			flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+
+			cfg, err := NewConfig()
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expected.HTTPAddress, cfg.HTTPAddress)
+			assert.Equal(t, tt.expected.StoreInterval, cfg.StoreInterval)
+			assert.Equal(t, tt.expected.FileStoragePath, cfg.FileStoragePath)
+			assert.Equal(t, tt.expected.Restore, cfg.Restore)
+			assert.Equal(t, tt.expected.DatabaseDSN, cfg.DatabaseDSN)
+			assert.Equal(t, tt.expected.Key, cfg.Key)
+		})
 	}
 }

--- a/internal/server/controller/controller.go
+++ b/internal/server/controller/controller.go
@@ -3,6 +3,7 @@ package controller
 
 import (
 	"github.com/frolmr/metrics/internal/server/config"
+	"github.com/frolmr/metrics/internal/server/decryptor"
 	"github.com/frolmr/metrics/internal/server/handlers"
 	"github.com/frolmr/metrics/internal/server/logger"
 	"github.com/frolmr/metrics/internal/server/middleware"
@@ -29,6 +30,7 @@ func (c *Controller) SetupHandlers(stor storage.Repository) chi.Router {
 
 	r.Use(middleware.Compressor)
 	r.Use(middleware.WithLog(c.logger))
+	r.Use(middleware.WithDecrypt(decryptor.NewDecryptor(c.config.CryptoKey)))
 	r.Use(middleware.WithSignature(c.config.Key))
 
 	rh := handlers.NewRequestHandler(stor)

--- a/internal/server/decryptor/decryptor.go
+++ b/internal/server/decryptor/decryptor.go
@@ -1,0 +1,40 @@
+package decryptor
+
+import (
+	"crypto/rsa"
+	"errors"
+)
+
+type Decryptor struct {
+	PrivateKey *rsa.PrivateKey
+	chunkSize  int
+}
+
+func NewDecryptor(pk *rsa.PrivateKey) *Decryptor {
+	d := Decryptor{PrivateKey: pk}
+	if pk != nil {
+		d.chunkSize = pk.Size()
+	}
+	return &d
+}
+
+func (d *Decryptor) DecryptData(encryptedData []byte) ([]byte, error) {
+	if d.PrivateKey == nil {
+		return nil, errors.New("no private key configured")
+	}
+
+	if len(encryptedData)%d.chunkSize != 0 {
+		return nil, errors.New("invalid encrypted data length")
+	}
+
+	var decryptedData []byte
+	for i := 0; i < len(encryptedData); i += d.chunkSize {
+		chunk := encryptedData[i : i+d.chunkSize]
+		decryptedChunk, err := rsa.DecryptPKCS1v15(nil, d.PrivateKey, chunk)
+		if err != nil {
+			return nil, err
+		}
+		decryptedData = append(decryptedData, decryptedChunk...)
+	}
+	return decryptedData, nil
+}

--- a/internal/server/decryptor/decryptor_test.go
+++ b/internal/server/decryptor/decryptor_test.go
@@ -1,0 +1,56 @@
+package decryptor
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecryptor(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	t.Run("successful decryption", func(t *testing.T) {
+		d := NewDecryptor(privateKey)
+
+		testData := []byte("test data to encrypt")
+
+		encrypted, err := rsa.EncryptPKCS1v15(rand.Reader, &privateKey.PublicKey, testData)
+		require.NoError(t, err)
+
+		decrypted, err := d.DecryptData(encrypted)
+		require.NoError(t, err)
+		require.Equal(t, testData, decrypted)
+	})
+
+	t.Run("invalid data length", func(t *testing.T) {
+		d := NewDecryptor(privateKey)
+
+		invalidData := make([]byte, d.chunkSize+1)
+
+		_, err := d.DecryptData(invalidData)
+		require.Error(t, err)
+		require.Equal(t, "invalid encrypted data length", err.Error())
+	})
+
+	t.Run("decryption failure", func(t *testing.T) {
+		d := NewDecryptor(privateKey)
+
+		invalidEncrypted := make([]byte, d.chunkSize)
+
+		_, err := d.DecryptData(invalidEncrypted)
+		require.Error(t, err)
+	})
+}
+
+func TestNewDecryptor(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	d := NewDecryptor(privateKey)
+	require.NotNil(t, d)
+	require.Equal(t, privateKey, d.PrivateKey)
+	require.Equal(t, privateKey.Size(), d.chunkSize)
+}

--- a/internal/server/logger/logger_test.go
+++ b/internal/server/logger/logger_test.go
@@ -1,5 +1,6 @@
 package logger
 
+//nolint:goimports // No clue why linter is diappointed
 import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"

--- a/internal/server/middleware/decryptor.go
+++ b/internal/server/middleware/decryptor.go
@@ -1,0 +1,39 @@
+package middleware
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+
+	"github.com/frolmr/metrics/internal/server/decryptor"
+)
+
+func WithDecrypt(d *decryptor.Decryptor) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(res http.ResponseWriter, req *http.Request) {
+			if d == nil || d.PrivateKey == nil {
+				next.ServeHTTP(res, req)
+				return
+			}
+
+			encryptedData, err := io.ReadAll(req.Body)
+			if err != nil {
+				http.Error(res, "failed to read request body", http.StatusBadRequest)
+				return
+			}
+			defer req.Body.Close()
+
+			decryptedData, err := d.DecryptData(encryptedData)
+			if err != nil {
+				http.Error(res, "failed to decrypt data", http.StatusBadRequest)
+				return
+			}
+
+			req.Body = io.NopCloser(bytes.NewReader(decryptedData))
+			req.ContentLength = int64(len(decryptedData))
+
+			next.ServeHTTP(res, req)
+		}
+		return http.HandlerFunc(fn)
+	}
+}

--- a/internal/server/middleware/decryptor_test.go
+++ b/internal/server/middleware/decryptor_test.go
@@ -1,0 +1,132 @@
+package middleware
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/frolmr/metrics/internal/server/decryptor"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithDecrypt(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	t.Run("successful decryption", func(t *testing.T) {
+		d := decryptor.NewDecryptor(privateKey)
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			data, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.Equal(t, "test data", string(data))
+			w.WriteHeader(http.StatusOK)
+		})
+
+		encrypted, err := rsa.EncryptPKCS1v15(rand.Reader, &privateKey.PublicKey, []byte("test data"))
+		require.NoError(t, err)
+
+		req := httptest.NewRequest("POST", "/", bytes.NewReader(encrypted))
+		req.Header.Set("Content-Type", "application/octet-stream")
+
+		rr := httptest.NewRecorder()
+
+		middleware := WithDecrypt(d)
+		middleware(handler).ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("no private key - pass through", func(t *testing.T) {
+		called := false
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			data, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.Equal(t, "test data", string(data))
+			w.WriteHeader(http.StatusOK)
+		})
+
+		d := &decryptor.Decryptor{PrivateKey: nil}
+
+		req := httptest.NewRequest("POST", "/", bytes.NewReader([]byte("test data")))
+		req.Header.Set("Content-Type", "application/octet-stream")
+
+		rr := httptest.NewRecorder()
+
+		middleware := WithDecrypt(d)
+		middleware(handler).ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		require.True(t, called, "handler should be called")
+	})
+
+	t.Run("nil decryptor - pass through", func(t *testing.T) {
+		called := false
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			data, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.Equal(t, "test data", string(data))
+			w.WriteHeader(http.StatusOK)
+		})
+
+		req := httptest.NewRequest("POST", "/", bytes.NewReader([]byte("test data")))
+		req.Header.Set("Content-Type", "application/octet-stream")
+
+		rr := httptest.NewRecorder()
+
+		middleware := WithDecrypt(nil)
+		middleware(handler).ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		require.True(t, called, "handler should be called")
+	})
+
+	t.Run("decryption failure", func(t *testing.T) {
+		d := decryptor.NewDecryptor(privateKey)
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("handler should not be called")
+		})
+
+		req := httptest.NewRequest("POST", "/", bytes.NewReader([]byte("invalid encrypted data")))
+		req.Header.Set("Content-Type", "application/octet-stream")
+
+		rr := httptest.NewRecorder()
+
+		middleware := WithDecrypt(d)
+		middleware(handler).ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+
+	t.Run("read body failure", func(t *testing.T) {
+		d := decryptor.NewDecryptor(privateKey)
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("handler should not be called")
+		})
+
+		req := httptest.NewRequest("POST", "/", &failingReader{})
+		req.Header.Set("Content-Type", "application/octet-stream")
+
+		rr := httptest.NewRecorder()
+
+		middleware := WithDecrypt(d)
+		middleware(handler).ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+}
+
+type failingReader struct{}
+
+func (r *failingReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("mock read error")
+}

--- a/internal/server/middleware/logger_test.go
+++ b/internal/server/middleware/logger_test.go
@@ -8,11 +8,13 @@ import (
 
 	"github.com/frolmr/metrics/internal/server/logger"
 	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 )
 
+//nolint:gocyclo // Not so important for tests
 func TestLoggingMiddleware(t *testing.T) {
 	core, recorded := observer.New(zapcore.InfoLevel)
 	mockLogger := &logger.Logger{
@@ -23,11 +25,13 @@ func TestLoggingMiddleware(t *testing.T) {
 	r.Use(WithLog(mockLogger))
 	r.Get("/test", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("test response"))
+		_, err := w.Write([]byte("test response"))
+		assert.NoError(t, err)
 	})
 	r.Get("/error", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("error response"))
+		_, err := w.Write([]byte("error response"))
+		assert.NoError(t, err)
 	})
 
 	tests := []struct {

--- a/internal/server/storage/retriable_db_storage.go
+++ b/internal/server/storage/retriable_db_storage.go
@@ -125,10 +125,6 @@ func (rs RetriableStorage) GetGaugeMetrics() (res map[string]float64, err error)
 }
 
 func (rs RetriableStorage) isRetriable(err error) bool {
-	switch {
-	case errors.Is(err, &pgconn.ConnectError{}):
-		return true
-	default:
-		return false
-	}
+	var connErr *pgconn.ConnectError
+	return errors.As(err, &connErr)
 }

--- a/internal/server/storage/retriable_db_storage_test.go
+++ b/internal/server/storage/retriable_db_storage_test.go
@@ -1,0 +1,386 @@
+package storage
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/frolmr/metrics/internal/domain"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetriableStorage_Ping_Success(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	mock.ExpectPing()
+
+	dbStorage := NewDBStorage(db)
+	retriableStorage := NewRetriableStorage(dbStorage)
+
+	err = retriableStorage.Ping()
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRetriableStorage_Ping_RetrySuccess(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	mock.ExpectPing().WillReturnError(&pgconn.ConnectError{})
+	mock.ExpectPing()
+
+	dbStorage := NewDBStorage(db)
+	retriableStorage := NewRetriableStorage(dbStorage)
+
+	start := time.Now()
+	err = retriableStorage.Ping()
+	duration := time.Since(start)
+
+	assert.NoError(t, err)
+	assert.True(t, duration >= time.Second, "should have waited at least 1 second")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRetriableStorage_Ping_NonRetriableError(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	mock.ExpectPing().WillReturnError(errors.New("non-retriable error"))
+
+	dbStorage := NewDBStorage(db)
+	retriableStorage := NewRetriableStorage(dbStorage)
+
+	start := time.Now()
+	err = retriableStorage.Ping()
+	duration := time.Since(start)
+
+	assert.Error(t, err)
+	assert.True(t, duration < time.Second, "should not have waited for retry")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRetriableStorage_Ping_AllRetriesFail(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	mock.ExpectPing().WillReturnError(&pgconn.ConnectError{})
+	mock.ExpectPing().WillReturnError(&pgconn.ConnectError{})
+	mock.ExpectPing().WillReturnError(&pgconn.ConnectError{})
+
+	dbStorage := NewDBStorage(db)
+	retriableStorage := NewRetriableStorage(dbStorage)
+
+	start := time.Now()
+	err = retriableStorage.Ping()
+	duration := time.Since(start)
+
+	assert.Error(t, err)
+	assert.True(t, duration >= 8*time.Second, "should have waited for all retries (1+2+5 seconds)")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRetriableStorage_UpdateCounterMetric_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	mock.ExpectPrepare("INSERT INTO counter_metrics")
+	mock.ExpectExec("INSERT INTO counter_metrics").WithArgs("test", 1).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	dbStorage := NewDBStorage(db)
+	retriableStorage := NewRetriableStorage(dbStorage)
+
+	err = retriableStorage.UpdateCounterMetric("test", 1)
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRetriableStorage_UpdateCounterMetric_RetrySuccess(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	mock.ExpectPrepare("INSERT INTO counter_metrics").WillReturnError(&pgconn.ConnectError{})
+	mock.ExpectPrepare("INSERT INTO counter_metrics")
+	mock.ExpectExec("INSERT INTO counter_metrics").WithArgs("test", 1).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	dbStorage := NewDBStorage(db)
+	retriableStorage := NewRetriableStorage(dbStorage)
+
+	start := time.Now()
+	err = retriableStorage.UpdateCounterMetric("test", 1)
+	duration := time.Since(start)
+
+	assert.NoError(t, err)
+	assert.True(t, duration >= time.Second, "should have waited at least 1 second")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRetriableStorage_UpdateCounterMetric_NonRetriableError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	mock.ExpectPrepare("INSERT INTO counter_metrics").WillReturnError(errors.New("non-retriable error"))
+
+	dbStorage := NewDBStorage(db)
+	retriableStorage := NewRetriableStorage(dbStorage)
+
+	start := time.Now()
+	err = retriableStorage.UpdateCounterMetric("test", 1)
+	duration := time.Since(start)
+
+	assert.Error(t, err)
+	assert.True(t, duration < time.Second, "should not have waited for retry")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRetriableStorage_UpdateGaugeMetric_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	mock.ExpectPrepare("INSERT INTO gauge_metrics")
+	mock.ExpectExec("INSERT INTO gauge_metrics").WithArgs("test", 1.1).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	dbStorage := NewDBStorage(db)
+	retriableStorage := NewRetriableStorage(dbStorage)
+
+	err = retriableStorage.UpdateGaugeMetric("test", 1.1)
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRetriableStorage_UpdateMetrics_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	fValue := float64(1.1)
+	metrics := []domain.Metrics{
+		{
+			ID:    "test",
+			MType: "gauge",
+			Value: &fValue,
+		},
+	}
+
+	mock.ExpectPrepare("INSERT INTO gauge_metrics")
+	mock.ExpectPrepare("INSERT INTO counter_metrics")
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO gauge_metrics").WithArgs("test", 1.1).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	dbStorage := NewDBStorage(db)
+	retriableStorage := NewRetriableStorage(dbStorage)
+
+	err = retriableStorage.UpdateMetrics(metrics)
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRetriableStorage_UpdateMetrics_RetrySuccess(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	fValue := float64(1.1)
+	metrics := []domain.Metrics{
+		{
+			ID:    "test",
+			MType: "gauge",
+			Value: &fValue,
+		},
+	}
+
+	mock.ExpectPrepare("INSERT INTO gauge_metrics").WillReturnError(&pgconn.ConnectError{})
+	mock.ExpectPrepare("INSERT INTO gauge_metrics")
+	mock.ExpectPrepare("INSERT INTO counter_metrics")
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO gauge_metrics").WithArgs("test", 1.1).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	dbStorage := NewDBStorage(db)
+	retriableStorage := NewRetriableStorage(dbStorage)
+
+	start := time.Now()
+	err = retriableStorage.UpdateMetrics(metrics)
+	duration := time.Since(start)
+
+	assert.NoError(t, err)
+	assert.True(t, duration >= time.Second, "should have waited at least 1 second")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRetriableStorage_GetCounterMetric_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	metricsMockRows := sqlmock.NewRows([]string{"value"}).AddRow("1")
+
+	mock.ExpectPrepare("SELECT value FROM counter_metrics")
+	mock.ExpectQuery("SELECT value FROM counter_metrics").WithArgs("test").WillReturnRows(metricsMockRows)
+
+	dbStorage := NewDBStorage(db)
+	retriableStorage := NewRetriableStorage(dbStorage)
+
+	val, err := retriableStorage.GetCounterMetric("test")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), val)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRetriableStorage_GetCounterMetric_RetrySuccess(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	mock.ExpectPrepare("SELECT value FROM counter_metrics").WillReturnError(&pgconn.ConnectError{})
+	metricsMockRows := sqlmock.NewRows([]string{"value"}).AddRow("1")
+	mock.ExpectPrepare("SELECT value FROM counter_metrics")
+	mock.ExpectQuery("SELECT value FROM counter_metrics").WithArgs("test").WillReturnRows(metricsMockRows)
+
+	dbStorage := NewDBStorage(db)
+	retriableStorage := NewRetriableStorage(dbStorage)
+
+	start := time.Now()
+	val, err := retriableStorage.GetCounterMetric("test")
+	duration := time.Since(start)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), val)
+	assert.True(t, duration >= time.Second, "should have waited at least 1 second")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRetriableStorage_GetGaugeMetric_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	metricsMockRows := sqlmock.NewRows([]string{"value"}).AddRow("1.1")
+
+	mock.ExpectPrepare("SELECT value FROM gauge_metrics")
+	mock.ExpectQuery("SELECT value FROM gauge_metrics").WithArgs("test").WillReturnRows(metricsMockRows)
+
+	dbStorage := NewDBStorage(db)
+	retriableStorage := NewRetriableStorage(dbStorage)
+
+	val, err := retriableStorage.GetGaugeMetric("test")
+	assert.NoError(t, err)
+	assert.Equal(t, 1.1, val)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRetriableStorage_GetCounterMetrics_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	metricsMockRows := sqlmock.NewRows([]string{"name", "value"}).AddRow("test", 1)
+
+	mock.ExpectPrepare("SELECT name, value FROM counter_metrics")
+	mock.ExpectQuery("SELECT name, value FROM counter_metrics").WillReturnRows(metricsMockRows)
+
+	dbStorage := NewDBStorage(db)
+	retriableStorage := NewRetriableStorage(dbStorage)
+
+	metrics, err := retriableStorage.GetCounterMetrics()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]int64{"test": 1}, metrics)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRetriableStorage_GetGaugeMetrics_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	metricsMockRows := sqlmock.NewRows([]string{"name", "value"}).AddRow("test", 1.1)
+
+	mock.ExpectPrepare("SELECT name, value FROM gauge_metrics")
+	mock.ExpectQuery("SELECT name, value FROM gauge_metrics").WillReturnRows(metricsMockRows)
+
+	dbStorage := NewDBStorage(db)
+	retriableStorage := NewRetriableStorage(dbStorage)
+
+	metrics, err := retriableStorage.GetGaugeMetrics()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]float64{"test": 1.1}, metrics)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRetriableStorage_IsRetriable(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	dbStorage := NewDBStorage(db)
+	retriableStorage := NewRetriableStorage(dbStorage)
+
+	connErr := &pgconn.ConnectError{}
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "ConnectError is retriable",
+			err:      connErr,
+			expected: true,
+		},
+		{
+			name:     "Other error is not retriable",
+			err:      errors.New("some error"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := retriableStorage.isRetriable(tt.err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/fileconfig/reader.go
+++ b/pkg/fileconfig/reader.go
@@ -1,0 +1,71 @@
+// Package fileconfig provides common functionality for reading configuration from files.
+package fileconfig
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// CommonConfig contains fields shared between agent and server configurations
+type CommonConfig struct {
+	Address   string `json:"address"`
+	CryptoKey string `json:"crypto_key"`
+	Key       string `json:"key"`
+	Scheme    string `json:"scheme"`
+}
+
+// AgentConfig represents agent-specific configuration from file
+type AgentConfig struct {
+	CommonConfig
+	ReportIntervalSec int `json:"report_interval"`
+	PollIntervalSec   int `json:"poll_interval"`
+	RateLimit         int `json:"rate_limit"`
+}
+
+// ServerConfig represents server-specific configuration from file
+type ServerConfig struct {
+	CommonConfig
+	Restore          bool   `json:"restore"`
+	StoreIntervalSec int    `json:"store_interval"`
+	StoreFile        string `json:"store_file"`
+	DatabaseDSN      string `json:"database_dsn"`
+}
+
+// ReadAgentConfig reads agent configuration from JSON file
+func ReadAgentConfig(path string) (*AgentConfig, error) {
+	if path == "" {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg AgentConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}
+
+// ReadServerConfig reads server configuration from JSON file
+func ReadServerConfig(path string) (*ServerConfig, error) {
+	if path == "" {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg ServerConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}

--- a/pkg/fileconfig/reader_test.go
+++ b/pkg/fileconfig/reader_test.go
@@ -1,0 +1,137 @@
+package fileconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadAgentConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	validConfig := `{
+		"address": "localhost:9090",
+		"report_interval": 5,
+		"poll_interval": 1,
+		"crypto_key": "/path/to/key.pem",
+		"key": "test_key",
+		"rate_limit": 10
+	}`
+
+	validPath := filepath.Join(tmpDir, "valid_config.json")
+	err := os.WriteFile(validPath, []byte(validConfig), 0600)
+	require.NoError(t, err)
+
+	invalidConfig := `{ invalid json }`
+	invalidPath := filepath.Join(tmpDir, "invalid_config.json")
+	err = os.WriteFile(invalidPath, []byte(invalidConfig), 0600)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		path    string
+		wantCfg *AgentConfig
+		wantErr bool
+	}{
+		{
+			name:    "valid config",
+			path:    validPath,
+			wantErr: false,
+			wantCfg: &AgentConfig{
+				CommonConfig: CommonConfig{
+					Address:   "localhost:9090",
+					CryptoKey: "/path/to/key.pem",
+					Key:       "test_key",
+				},
+				ReportIntervalSec: 5,
+				PollIntervalSec:   1,
+				RateLimit:         10,
+			},
+		},
+		{
+			name:    "invalid json",
+			path:    invalidPath,
+			wantErr: true,
+		},
+		{
+			name:    "non-existent file",
+			path:    filepath.Join(tmpDir, "nonexistent.json"),
+			wantErr: true,
+		},
+		{
+			name:    "empty path",
+			path:    "",
+			wantErr: false,
+			wantCfg: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := ReadAgentConfig(tt.path)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantCfg, cfg)
+		})
+	}
+}
+
+func TestReadServerConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	validConfig := `{
+		"address": "localhost:9090",
+		"store_interval": 30,
+		"store_file": "/path/to/store.db",
+		"restore": true,
+		"database_dsn": "postgres://user:pass@localhost:5432/db",
+		"crypto_key": "/path/to/key.pem",
+		"key": "test_key"
+	}`
+
+	validPath := filepath.Join(tmpDir, "valid_config.json")
+	err := os.WriteFile(validPath, []byte(validConfig), 0600)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		path    string
+		wantCfg *ServerConfig
+		wantErr bool
+	}{
+		{
+			name:    "valid config",
+			path:    validPath,
+			wantErr: false,
+			wantCfg: &ServerConfig{
+				CommonConfig: CommonConfig{
+					Address:   "localhost:9090",
+					CryptoKey: "/path/to/key.pem",
+					Key:       "test_key",
+				},
+				StoreIntervalSec: 30,
+				StoreFile:        "/path/to/store.db",
+				Restore:          true,
+				DatabaseDSN:      "postgres://user:pass@localhost:5432/db",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := ReadServerConfig(tt.path)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantCfg, cfg)
+		})
+	}
+}


### PR DESCRIPTION
Increment 21
- в конфиги агента и сервера добавлены ключи для приватного и публичного
  ключей шифрования
- агент шифрует данные перед отправкой
- сервер при наличии ключа дешифрует данные в запросе

Increment 22
- добавлена возможность загружать конфиги для агента и сервера из json
  файла, имеющего наименьший приоритет

Increment 23
- добавлен graceful shutdown механизм для сервера
- исправлены ошибки линтера
- добавлены тесты на retriable storage, тестовое покрытие доведено до
  70.8%